### PR TITLE
Синхронизация портов в калибровочных скриптах

### DIFF
--- a/calibration/magneto.m
+++ b/calibration/magneto.m
@@ -2,7 +2,7 @@ instrreset;
 
 % Enter Your Raspberry Pi pyIMUCalibrationDataServer host
 HOST = '192.168.0.76';
-PORT = 21566;
+PORT = 21567;
 
 % Clear console and workspace
 clc;


### PR DESCRIPTION
День добрый!
Шикарная либа, отличная работа!

В калибровочных скриптах заметил, что в матлабе и питоне разные порты, соотв-нно подключиться невозожно.

Предлагаю поставить одинаковый порт в обоих скриптах.